### PR TITLE
feat: move set to persistent wal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ target/
 # Added by cargo
 
 /target
+
+kvs.db

--- a/src/bin/kvs.rs
+++ b/src/bin/kvs.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand};
 use kvs::{KvStore, Result};
-use std::{path::PathBuf, process::exit};
+use std::process::exit;
 
 #[derive(Parser, Debug)]
 #[command(name = env!("CARGO_PKG_NAME"), version, about, long_about = None)]
@@ -19,7 +19,7 @@ enum Commands {
 fn main() -> Result<()> {
     let args = Args::parse();
 
-    let mut kvs = KvStore::open(PathBuf::from("./kvs.db"))?;
+    let mut kvs = KvStore::open(std::env::current_dir()?)?;
 
     match &args.command {
         Commands::Get { key } => {

--- a/src/bin/kvs.rs
+++ b/src/bin/kvs.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand};
 use kvs::{KvStore, Result};
-use std::process::exit;
+use std::{path::PathBuf, process::exit};
 
 #[derive(Parser, Debug)]
 #[command(name = env!("CARGO_PKG_NAME"), version, about, long_about = None)]
@@ -18,7 +18,8 @@ enum Commands {
 
 fn main() -> Result<()> {
     let args = Args::parse();
-    let mut kvs = KvStore::new();
+
+    let mut kvs = KvStore::open(PathBuf::from("./kvs.db"))?;
 
     match &args.command {
         Commands::Get { key } => {


### PR DESCRIPTION
This PR begins to move the WAL out of memory and on to a persistent file format of serialized JSON. This will support adding `set` and `rm` commands and then allowing our in memory index to store a pointer to a location in the file. 

In memory this is represented as a hash map
```
key -> file offset (0)
```
Then on disk 
```
cat -p kvs.db
{"action":"SET","key":"hello","value":"world"} <- 0 
```